### PR TITLE
fix: Test error case fix for Sorter class

### DIFF
--- a/gTest/sorter_test.cpp
+++ b/gTest/sorter_test.cpp
@@ -44,9 +44,9 @@ protected:
 };
 
 TEST_F(SortTest, SORT_TEST1) {
-    EXPECT_EQ(81235564, employees[0]->employee_number);
-    EXPECT_EQ(88114052, employees[1]->employee_number);
-    EXPECT_EQ(15123099, employees[2]->employee_number);
-    EXPECT_EQ(21171756, employees[8]->employee_number);
+    EXPECT_EQ(1981235564, employees[0]->employee_number);
+    EXPECT_EQ(1988114052, employees[1]->employee_number);
+    EXPECT_EQ(2015123099, employees[2]->employee_number);
+    EXPECT_EQ(2021171756, employees[8]->employee_number);
     EXPECT_TRUE(true);
 }


### PR DESCRIPTION
Employeee number 저장 시 year 정보가 2자리 숫자에서 4자리 숫자로 저장되도록 Employee class가 변경되어 test case도 변경