### PR TITLE
refactor: Change Employees member function name

### DIFF
--- a/Employees/Employees.cpp
+++ b/Employees/Employees.cpp
@@ -182,7 +182,7 @@ public:
 		return ret;
 	}
 
-	virtual const size_t getEmployeeNumbers() const {
+	virtual const size_t Size() const {
 		return list.size();
 	}
 

--- a/Employees/Employees.h
+++ b/Employees/Employees.h
@@ -52,7 +52,7 @@ public:
 	virtual employeeList Del(Employee&) = 0;
 	virtual employeeList Modify(Employee&, std::function<void (Employee&)>) = 0;
 	virtual employeeList Search(std::function<bool(Employee&)>) = 0;
-	virtual const size_t getEmployeeNumbers() const = 0;
+	virtual const size_t Size() const = 0;
 };
 
 Employees* CreateEmployees();

--- a/gTest/employees_test.cpp
+++ b/gTest/employees_test.cpp
@@ -57,14 +57,14 @@ TEST(EmployeeTest, EmployeeOperator) {
 }
 
 TEST_F(clientTest, EmployeesTestSize) {
-    EXPECT_EQ(db->getEmployeeNumbers(), 9);
+    EXPECT_EQ(db->Size(), 9);
 }
 
 TEST_F(clientTest, EmployeesTestAdd) {
     Employee empl = { "12234575", "EOJOEI", "EWFWEF", "CL2", "5332", "6544", "20152623", "PRO" };
     db->Add(empl);
 
-    EXPECT_EQ(db->getEmployeeNumbers(), 10);
+    EXPECT_EQ(db->Size(), 10);
 }
 
 TEST_F(clientTest, EmployeesTestDelete) {
@@ -73,12 +73,12 @@ TEST_F(clientTest, EmployeesTestDelete) {
     Employee empl1 = { "17111236", "VSID", "TVO", "CL1", "3669", "1077", "20120718", "PRO" };
     del_list = db->Del(empl1);
     EXPECT_EQ(del_list.size(), 1);
-    EXPECT_EQ(db->getEmployeeNumbers(), 8);
+    EXPECT_EQ(db->Size(), 8);
 
     Employee empl2 = { "19129568", "SRERLALH", "HMEF", "CL2", "3091", "9521", "19640910", "PRO" };
     del_list = db->Del(empl2);
     EXPECT_EQ(del_list.size(), 1);
-    EXPECT_EQ(db->getEmployeeNumbers(), 7);
+    EXPECT_EQ(db->Size(), 7);
 
     Employee empl3 = { "32523452", "SRERLALH", "HMEF", "CL2", "3091", "9521", "19640910", "PRO" };
     EXPECT_ANY_THROW(db->Del(empl3));


### PR DESCRIPTION
list에 저장된 Employee 갯수를 반환하는 함수 이름이 사번을 지칭하는 EmployeeNumber와 혼동될 우려가 있어 이름을 변경함