### PR TITLE
refator: Remove SearchInput class

### DIFF
--- a/Command/Command.cpp
+++ b/Command/Command.cpp
@@ -52,59 +52,61 @@ static string Output(string name, bool opt, employeeList& list) {
 	return ret;
 }
 
-SearchInput Command::get_search_input(void) {
-	SearchInput search_input;
-	search_input.search_pattern = get_command()[5];
-	search_input.search_pattern.erase(search_input.search_pattern.find_last_not_of(" \t\n\r\f\v") + 1);
+string Command::GetSearchPattern(void) {
+	string search_pattern = get_command()[5];
+	search_pattern.erase(search_pattern.find_last_not_of(" \t\n\r\f\v") + 1);
+	return search_pattern ;
+}
 
+SearchType Command::GetSearchType(void) {
 	if ("employeeNum" == get_command()[4]) {
-		search_input.search_type = SearchType::EMPLOYEE_NUM;
+		return SearchType::EMPLOYEE_NUM;
 	}
 	else if ("name" == get_command()[4]) {
 		if ("-f" == get_command()[2]) {
-			search_input.search_type = SearchType::FIRST_NAME;
+			return SearchType::FIRST_NAME;
 		}
 		else if ("-l" == get_command()[2]) {
-			search_input.search_type = SearchType::LAST_NAME;
+			return SearchType::LAST_NAME;
 		}
 		else {
-			search_input.search_type = SearchType::NAME;
+			return SearchType::NAME;
 		}
 	}
 	else if ("cl" == get_command()[4]) {
-		search_input.search_type = SearchType::CL;
+		return SearchType::CL;
 	}
 	else if ("phoneNum" == get_command()[4]) {
 		if ("-m" == get_command()[2]) {
-			search_input.search_type = SearchType::PHONE_NUM_MID;
+			return SearchType::PHONE_NUM_MID;
 		}
 		else if ("-l" == get_command()[2]) {
-			search_input.search_type = SearchType::PHONE_NUM_LAST;
+			return SearchType::PHONE_NUM_LAST;
 		}
 		else {
-			search_input.search_type = SearchType::PHONE_NUM;
+			return SearchType::PHONE_NUM;
 		}
 	}
 	else if ("birthday" == get_command()[4]) {
 		if ("-y" == get_command()[2]) {
-			search_input.search_type = SearchType::BIRTHDAY_YEAR;
+			return SearchType::BIRTHDAY_YEAR;
 		}
 		else if ("-m" == get_command()[2]) {
-			search_input.search_type = SearchType::BIRTHDAY_MONTH;
+			return SearchType::BIRTHDAY_MONTH;
 		}
 		else if ("-d" == get_command()[2]) {
-			search_input.search_type = SearchType::BIRTHDAY_DAY;
+			return SearchType::BIRTHDAY_DAY;
 		}
 		else {
-			search_input.search_type = SearchType::BIRTHDAY;
+			return SearchType::BIRTHDAY;
 		}
 	}
 	else if ("certi" == get_command()[4])
 	{
-		search_input.search_type = SearchType::CERTI;
+		return SearchType::CERTI;
 	}
 
-	return search_input;
+	throw invalid_argument("Invalid search type\n");
 }
 
 string AddCommand::Process(Employees* database) {

--- a/Command/Command.h
+++ b/Command/Command.h
@@ -26,7 +26,8 @@ public:
 		return this->name_;
 	}
 
-	virtual SearchInput get_search_input(void);
+	virtual string GetSearchPattern(void);
+	virtual SearchType GetSearchType(void);
 
 	void print_error_msg(void) {
 		string errorMessage = "## ERROR ::" + get_command()[0] + ". size: ";
@@ -47,7 +48,7 @@ public:
 	employeeList SearchEmployees(Employees* database) {
 		shared_ptr<Search> search(new Search());
 		search->SetEmployeeList(database);
-		return std::move(search->DoSearch(get_search_input()));
+		return std::move(search->DoSearch(GetSearchType(), GetSearchPattern()));
 	}
 
 	vector<Employee*> result_employees;

--- a/Search/Search.cpp
+++ b/Search/Search.cpp
@@ -1,72 +1,72 @@
 ﻿
 #include "Search.h"
 
-EmployNumCondition::EmployNumCondition(SearchInput in) {
-	this->employee_number = stoi(in.search_pattern);
+EmployNumCondition::EmployNumCondition(string search_pattern) {
+	this->employee_number = stoi(search_pattern);
 
 	Match = [this](Employee& in) -> bool {
 		return in.employee_number % 100000000 == this->employee_number;
 	};
 }
 
-NameCondition::NameCondition(SearchInput in) {
-	this->name = in.search_pattern;
+NameCondition::NameCondition(string search_pattern) {
+	this->name = search_pattern;
 
 	Match = [this](Employee& in) -> bool {
 		return in.first_name + " " + in.last_name == this->name;
 	};
 }
 
-FirstNameCondition::FirstNameCondition(SearchInput in) {
-	this->first_name = in.search_pattern;
+FirstNameCondition::FirstNameCondition(string search_pattern) {
+	this->first_name = search_pattern;
 
 	Match = [this](Employee& in) -> bool {
 		return in.first_name == this->first_name;
 	};
 }
 
-LastNameCondition::LastNameCondition(SearchInput in) {
-	this->last_name = in.search_pattern;
+LastNameCondition::LastNameCondition(string search_pattern) {
+	this->last_name = search_pattern;
 
 	Match = [this](Employee& in) -> bool {
 		return in.last_name == this->last_name;
 	};
 }
 
-PhoneNumCondition::PhoneNumCondition(SearchInput in) {
-	this->phone_num = in.search_pattern;
+PhoneNumCondition::PhoneNumCondition(string search_pattern) {
+	this->phone_num = search_pattern;
 
 	Match = [this](Employee& in) -> bool {
 		return "010-" + std::to_string(in.phone_num_mid) + "-" + std::to_string(in.phone_num_last) == this->phone_num;
 	};
 }
 
-PhoneNumMidCondition::PhoneNumMidCondition(SearchInput in) {
-	this->phone_num_mid = stoi(in.search_pattern);
+PhoneNumMidCondition::PhoneNumMidCondition(string search_pattern) {
+	this->phone_num_mid = stoi(search_pattern);
 
 	Match = [this](Employee& in) -> bool {
 		return in.phone_num_mid == this->phone_num_mid;
 	};
 }
 
-PhoneNumLastCondition::PhoneNumLastCondition(SearchInput in) {
-	this->phone_num_last = stoi(in.search_pattern);
+PhoneNumLastCondition::PhoneNumLastCondition(string search_pattern) {
+	this->phone_num_last = stoi(search_pattern);
 
 	Match = [this](Employee& in) -> bool {
 		return in.phone_num_last == this->phone_num_last;
 	};
 }
 
-BirthCondition::BirthCondition(SearchInput in) {
-	this->birth = stoi(in.search_pattern);
+BirthCondition::BirthCondition(string search_pattern) {
+	this->birth = stoi(search_pattern);
 
 	Match = [this](Employee& in) -> bool {
 		return in.birth == this->birth;
 	};
 }
 
-BirthYearCondition::BirthYearCondition(SearchInput in) {
-	this->year = stoi(in.search_pattern);
+BirthYearCondition::BirthYearCondition(string search_pattern) {
+	this->year = stoi(search_pattern);
 
 	Match = [this](Employee& in) -> bool {
 		unsigned year = in.birth / 10000;
@@ -74,8 +74,8 @@ BirthYearCondition::BirthYearCondition(SearchInput in) {
 	};
 }
 
-BirthMonthCondition::BirthMonthCondition(SearchInput in) {
-	this->month = stoi(in.search_pattern);
+BirthMonthCondition::BirthMonthCondition(string search_pattern) {
+	this->month = stoi(search_pattern);
 	if (this->month < 0 || this->month > 12) {
 		throw std::out_of_range("Search month range error!");
 	}
@@ -89,8 +89,8 @@ BirthMonthCondition::BirthMonthCondition(SearchInput in) {
 	};
 }
 
-BirthDayCondition::BirthDayCondition(SearchInput in) {
-	this->day = stoi(in.search_pattern);
+BirthDayCondition::BirthDayCondition(string search_pattern) {
+	this->day = stoi(search_pattern);
 	if (this->day < 0 || this->day > 31) {
 		throw std::out_of_range("Search day range error!");
 	}
@@ -104,16 +104,16 @@ BirthDayCondition::BirthDayCondition(SearchInput in) {
 	};
 }
 
-ClCondition::ClCondition(SearchInput in) {
-	this->cl = StrToCL(in.search_pattern);
+ClCondition::ClCondition(string search_pattern) {
+	this->cl = StrToCL(search_pattern);
 
 	Match = [this](Employee& in) -> bool {
 		return in.cl == this->cl;
 	};
 }
 
-CertiCondition::CertiCondition(SearchInput in) {
-	this->certi = StrToCerti(in.search_pattern);
+CertiCondition::CertiCondition(string search_pattern) {
+	this->certi = StrToCerti(search_pattern);
 
 	Match = [this](Employee& in) -> bool {
 		return in.certi == this->certi;
@@ -124,23 +124,23 @@ void Search::SetEmployeeList(Employees* employees_ptr) {
 	this->employees_ = employees_ptr;
 }
 
-employeeList Search::DoSearch(SearchInput in) {
+employeeList Search::DoSearch(SearchType  search_type, string search_pattern) {
 	employeeList searchOutput;
 
-	switch (in.search_type)	{
-	case SearchType::EMPLOYEE_NUM: 	 this->search_condition = new EmployNumCondition(in);	  break;
-	case SearchType::NAME:       	 this->search_condition = new NameCondition(in);	      break;
-	case SearchType::FIRST_NAME:	 this->search_condition = new FirstNameCondition(in);	  break;
-	case SearchType::LAST_NAME:		 this->search_condition = new LastNameCondition(in);	  break;
-	case SearchType::PHONE_NUM:  	 this->search_condition = new PhoneNumCondition(in);	  break;
-	case SearchType::PHONE_NUM_MID:	 this->search_condition = new PhoneNumMidCondition(in);	  break;
-	case SearchType::PHONE_NUM_LAST: this->search_condition = new PhoneNumLastCondition(in);  break;
-	case SearchType::BIRTHDAY:	     this->search_condition = new BirthCondition(in);	      break;
-	case SearchType::BIRTHDAY_YEAR:	 this->search_condition = new BirthYearCondition(in);	  break;
-	case SearchType::BIRTHDAY_MONTH: this->search_condition = new BirthMonthCondition(in);	  break;
-	case SearchType::BIRTHDAY_DAY:	 this->search_condition = new BirthDayCondition(in);	  break;
-	case SearchType::CL:	         this->search_condition = new ClCondition(in);	          break;
-	case SearchType::CERTI:	         this->search_condition = new CertiCondition(in);	      break;
+	switch (search_type)	{
+	case SearchType::EMPLOYEE_NUM: 	 this->search_condition = new EmployNumCondition(search_pattern);	  break;
+	case SearchType::NAME:       	 this->search_condition = new NameCondition(search_pattern);	      break;
+	case SearchType::FIRST_NAME:	 this->search_condition = new FirstNameCondition(search_pattern);	  break;
+	case SearchType::LAST_NAME:		 this->search_condition = new LastNameCondition(search_pattern);	  break;
+	case SearchType::PHONE_NUM:  	 this->search_condition = new PhoneNumCondition(search_pattern);	  break;
+	case SearchType::PHONE_NUM_MID:	 this->search_condition = new PhoneNumMidCondition(search_pattern);	  break;
+	case SearchType::PHONE_NUM_LAST: this->search_condition = new PhoneNumLastCondition(search_pattern);  break;
+	case SearchType::BIRTHDAY:	     this->search_condition = new BirthCondition(search_pattern);	      break;
+	case SearchType::BIRTHDAY_YEAR:	 this->search_condition = new BirthYearCondition(search_pattern);	  break;
+	case SearchType::BIRTHDAY_MONTH: this->search_condition = new BirthMonthCondition(search_pattern);	  break;
+	case SearchType::BIRTHDAY_DAY:	 this->search_condition = new BirthDayCondition(search_pattern);	  break;
+	case SearchType::CL:	         this->search_condition = new ClCondition(search_pattern);	          break;
+	case SearchType::CERTI:	         this->search_condition = new CertiCondition(search_pattern);	      break;
 	default: throw std::out_of_range("SearchType range error!");
 	}
 

--- a/Search/Search.h
+++ b/Search/Search.h
@@ -10,6 +10,8 @@
 #include <string>
 #include "../Employees/employees.h"
 
+using namespace std;
+
 enum class SearchType {
 	EMPLOYEE_NUM,
 	NAME,
@@ -26,12 +28,6 @@ enum class SearchType {
 	CERTI,
 };
 
-class SearchInput {
-public:
-	SearchType  search_type;
-	std::string search_pattern;
-};
-
 class SearchCondition {
 public:
 	std::function<bool(Employee&)> Match;
@@ -39,91 +35,91 @@ public:
 
 class EmployNumCondition : public SearchCondition {
 public:
-	EmployNumCondition(SearchInput in);
+	EmployNumCondition(string search_pattern);
 private:
 	unsigned  employee_number;
 };
 
 class NameCondition : public SearchCondition {
 public:
-	NameCondition(SearchInput in);
+	NameCondition(string search_pattern);
 private:
 	std::string name;
 };
 
 class FirstNameCondition : public SearchCondition {
 public:
-	FirstNameCondition(SearchInput in);
+	FirstNameCondition(string search_pattern);
 private:
 	std::string first_name;
 };
 
 class LastNameCondition : public SearchCondition {
 public:
-	LastNameCondition(SearchInput in);
+	LastNameCondition(string search_pattern);
 private:
 	std::string last_name;
 };
 
 class PhoneNumCondition : public SearchCondition {
 public:
-	PhoneNumCondition(SearchInput in);
+	PhoneNumCondition(string search_pattern);
 private:
 	std::string phone_num;
 };
 
 class PhoneNumMidCondition : public SearchCondition {
 public:
-	PhoneNumMidCondition(SearchInput in);
+	PhoneNumMidCondition(string search_pattern);
 private:
 	unsigned phone_num_mid;
 };
 
 class PhoneNumLastCondition : public SearchCondition {
 public:
-	PhoneNumLastCondition(SearchInput in);
+	PhoneNumLastCondition(string search_pattern);
 private:
 	unsigned phone_num_last;
 };
 
 class BirthCondition : public SearchCondition {
 public:
-	BirthCondition(SearchInput in);
+	BirthCondition(string search_pattern);
 private:
 	unsigned birth;
 };
 
 class BirthYearCondition : public SearchCondition {
 public:
-	BirthYearCondition(SearchInput in);
+	BirthYearCondition(string search_pattern);
 private:
 	unsigned year;
 };
 
 class BirthMonthCondition : public SearchCondition {
 public:
-	BirthMonthCondition(SearchInput in);
+	BirthMonthCondition(string search_pattern);
 private:
 	unsigned month;
 };
 
 class BirthDayCondition : public SearchCondition {
 public:
-	BirthDayCondition(SearchInput in);
+	BirthDayCondition(string search_pattern);
 private:
 	unsigned day;
 };
 
 class ClCondition : public SearchCondition {
 public:
-	ClCondition(SearchInput in);
+	ClCondition(string search_pattern);
 private:
 	CL cl;
 };
 
 class CertiCondition : public SearchCondition {
 public:
-	CertiCondition(SearchInput in);
+	CertiCondition(string search_pattern);
 private:
 	CERTI certi;
 };
@@ -132,7 +128,7 @@ private:
 class Search {
 public:
 	void SetEmployeeList(Employees* employees_ptr);
-	employeeList DoSearch(SearchInput in);
+	employeeList DoSearch(SearchType  search_type, string search_pattern);
 
 private:
 	Employees* employees_;

--- a/gTest/Search_test.cpp
+++ b/gTest/Search_test.cpp
@@ -31,16 +31,17 @@ private :
 TEST(Search_EmployNum, EmplyNum_20123099) {
 	SearchTestDb search_test_db;
 	Search search;
-	SearchInput in;
+	SearchType search_type;
+	string search_pattern;
 	employeeList out;
 	employeeList::iterator it;
 
 	search.SetEmployeeList(search_test_db.GetEmployeeDb());
 
-	in.search_pattern = "20123099";
-	in.search_type = SearchType::EMPLOYEE_NUM;
+	search_pattern = "20123099";
+	search_type = SearchType::EMPLOYEE_NUM;
 
-	out = search.DoSearch(in);
+	out = search.DoSearch(search_type, search_pattern);
 
 	it = out.begin();
 	ASSERT_EQ(out.size(), 1);
@@ -51,16 +52,17 @@ TEST(Search_EmployNum, EmplyNum_20123099) {
 TEST(Search_Name,Name_CLEE) {
 	SearchTestDb search_test_db;
 	Search search;
-	SearchInput in;
+	SearchType search_type;
+	string search_pattern;
 	employeeList out;
 	employeeList::iterator it;
 
 	search.SetEmployeeList(search_test_db.GetEmployeeDb());
 
-	in.search_pattern = "C LEE";
-	in.search_type = SearchType::NAME;
+	search_pattern = "C LEE";
+	search_type = SearchType::NAME;
 
-	out = search.DoSearch(in);
+	out = search.DoSearch(search_type, search_pattern);
 
 	it = out.begin();
 	ASSERT_EQ(out.size(), 1);
@@ -70,16 +72,17 @@ TEST(Search_Name,Name_CLEE) {
 TEST(Search_FirstName, FirstName_A) {
 	SearchTestDb search_test_db;
 	Search search;
-	SearchInput in;
+	SearchType search_type;
+	string search_pattern;
 	employeeList out;
 	employeeList::iterator it;
 
 	search.SetEmployeeList( search_test_db.GetEmployeeDb() );
 
-	in.search_pattern = "A";
-	in.search_type = SearchType::FIRST_NAME;
+	search_pattern = "A";
+	search_type = SearchType::FIRST_NAME;
 
-	out = search.DoSearch(in);
+	out = search.DoSearch(search_type, search_pattern);
 
 	it = out.begin();
 	ASSERT_EQ(out.size(), 2);
@@ -91,16 +94,17 @@ TEST(Search_FirstName, FirstName_A) {
 TEST(Search_LastName, LastName_LEE) {
 	SearchTestDb search_test_db;
 	Search search;
-	SearchInput in;
+	SearchType search_type;
+	string search_pattern;
 	employeeList out;
 	employeeList::iterator it;
 
 	search.SetEmployeeList(search_test_db.GetEmployeeDb());
 
-	in.search_pattern = "LEE";
-	in.search_type = SearchType::LAST_NAME;
+	search_pattern = "LEE";
+	search_type = SearchType::LAST_NAME;
 
-	out = search.DoSearch(in);
+	out = search.DoSearch(search_type, search_pattern);
 
 	it = out.begin();
 	ASSERT_EQ(out.size(), 2);
@@ -112,16 +116,17 @@ TEST(Search_LastName, LastName_LEE) {
 TEST(Search_PhoneNum, PhoneNum_12377524) {
 	SearchTestDb search_test_db;
 	Search search;
-	SearchInput in;
+	SearchType search_type;
+	string search_pattern;
 	employeeList out;
 	employeeList::iterator it;
 
 	search.SetEmployeeList(search_test_db.GetEmployeeDb());
 
-	in.search_pattern = "010-1237-7524";
-	in.search_type = SearchType::PHONE_NUM;
+	search_pattern = "010-1237-7524";
+	search_type = SearchType::PHONE_NUM;
 
-	out = search.DoSearch(in);
+	out = search.DoSearch(search_type, search_pattern);
 
 	it = out.begin();
 	ASSERT_EQ(out.size(), 1);
@@ -131,16 +136,17 @@ TEST(Search_PhoneNum, PhoneNum_12377524) {
 TEST(Search_PhoneNumMid, PhoneNumMid_1237) {
 	SearchTestDb search_test_db;
 	Search search;
-	SearchInput in;
+	SearchType search_type;
+	string search_pattern;
 	employeeList out;
 	employeeList::iterator it;
 
 	search.SetEmployeeList(search_test_db.GetEmployeeDb());
 
-	in.search_pattern = "1237";
-	in.search_type = SearchType::PHONE_NUM_MID;
+	search_pattern = "1237";
+	search_type = SearchType::PHONE_NUM_MID;
 
-	out = search.DoSearch(in);
+	out = search.DoSearch(search_type, search_pattern);
 
 	it = out.begin();
 	ASSERT_EQ(out.size(), 1);
@@ -150,16 +156,17 @@ TEST(Search_PhoneNumMid, PhoneNumMid_1237) {
 TEST(Search_PhoneNumLast, PhoneNumLast_7824) {
 	SearchTestDb search_test_db;
 	Search search;
-	SearchInput in;
+	SearchType search_type;
+	string search_pattern;
 	employeeList out;
 	employeeList::iterator it;
 
 	search.SetEmployeeList(search_test_db.GetEmployeeDb());
 
-	in.search_pattern = "7824";
-	in.search_type = SearchType::PHONE_NUM_LAST;
+	search_pattern = "7824";
+	search_type = SearchType::PHONE_NUM_LAST;
 
-	out = search.DoSearch(in);
+	out = search.DoSearch(search_type, search_pattern);
 
 	it = out.begin();
 	ASSERT_EQ(out.size(), 1);
@@ -169,16 +176,17 @@ TEST(Search_PhoneNumLast, PhoneNumLast_7824) {
 TEST(Search_Birthday, Birthday_19641112) {
 	SearchTestDb search_test_db;
 	Search search;
-	SearchInput in;
+	SearchType search_type;
+	string search_pattern;
 	employeeList out;
 	employeeList::iterator it;
 
 	search.SetEmployeeList(search_test_db.GetEmployeeDb());
 
-	in.search_pattern = "19641112";
-	in.search_type = SearchType::BIRTHDAY;
+	search_pattern = "19641112";
+	search_type = SearchType::BIRTHDAY;
 
-	out = search.DoSearch(in);
+	out = search.DoSearch(search_type, search_pattern);
 
 	it = out.begin();
 	ASSERT_EQ(out.size(), 1);
@@ -188,16 +196,17 @@ TEST(Search_Birthday, Birthday_19641112) {
 TEST(Search_BirthdayYear, BirthdayYear_1977) {
 	SearchTestDb search_test_db;
 	Search search;
-	SearchInput in;
+	SearchType search_type;
+	string search_pattern;
 	employeeList out;
 	employeeList::iterator it;
 
 	search.SetEmployeeList(search_test_db.GetEmployeeDb());
 
-	in.search_pattern = "1977";
-	in.search_type = SearchType::BIRTHDAY_YEAR;
+	search_pattern = "1977";
+	search_type = SearchType::BIRTHDAY_YEAR;
 
-	out = search.DoSearch(in);
+	out = search.DoSearch(search_type, search_pattern);
 
 	it = out.begin();
 	ASSERT_EQ(out.size(), 2);
@@ -209,16 +218,17 @@ TEST(Search_BirthdayYear, BirthdayYear_1977) {
 TEST(Search_BirthdayMonth, BirthdayMonth_11) {
 	SearchTestDb search_test_db;
 	Search search;
-	SearchInput in;
+	SearchType search_type;
+	string search_pattern;
 	employeeList out;
 	employeeList::iterator it;
 
 	search.SetEmployeeList(search_test_db.GetEmployeeDb());
 
-	in.search_pattern = "11";
-	in.search_type = SearchType::BIRTHDAY_MONTH;
+	search_pattern = "11";
+	search_type = SearchType::BIRTHDAY_MONTH;
 
-	out = search.DoSearch(in);
+	out = search.DoSearch(search_type, search_pattern);
 
 	it = out.begin();
 	ASSERT_EQ(out.size(), 6);
@@ -238,16 +248,17 @@ TEST(Search_BirthdayMonth, BirthdayMonth_11) {
 TEST(Search_BirthdayDay, BirthdayDay_12) {
 	SearchTestDb search_test_db;
 	Search search;
-	SearchInput in;
+	SearchType search_type;
+	string search_pattern;
 	employeeList out;
 	employeeList::iterator it;
 
 	search.SetEmployeeList(search_test_db.GetEmployeeDb());
 
-	in.search_pattern = "12";
-	in.search_type = SearchType::BIRTHDAY_DAY;
+	search_pattern = "12";
+	search_type = SearchType::BIRTHDAY_DAY;
 
-	out = search.DoSearch(in);
+	out = search.DoSearch(search_type, search_pattern);
 
 	it = out.begin();
 	ASSERT_EQ(out.size(), 3);
@@ -261,16 +272,17 @@ TEST(Search_BirthdayDay, BirthdayDay_12) {
 TEST(Search_Cl, Cl_2) {
 	SearchTestDb search_test_db;
 	Search search;
-	SearchInput in;
+	SearchType search_type;
+	string search_pattern;
 	employeeList out;
 	employeeList::iterator it;
 
 	search.SetEmployeeList(search_test_db.GetEmployeeDb());
 
-	in.search_pattern = "CL2";
-	in.search_type = SearchType::CL;
+	search_pattern = "CL2";
+	search_type = SearchType::CL;
 
-	out = search.DoSearch(in);
+	out = search.DoSearch(search_type, search_pattern);
 
 	it = out.begin();
 	ASSERT_EQ(out.size(), 2);
@@ -282,16 +294,17 @@ TEST(Search_Cl, Cl_2) {
 TEST(Search_Certi, Certi_ADV) {
 	SearchTestDb search_test_db;
 	Search search;
-	SearchInput in;
+	SearchType search_type;
+	string search_pattern;
 	employeeList out;
 	employeeList::iterator it;
 
 	search.SetEmployeeList(search_test_db.GetEmployeeDb());
 
-	in.search_pattern = "ADV";
-	in.search_type = SearchType::CERTI;
+	search_pattern = "ADV";
+	search_type = SearchType::CERTI;
 
-	out = search.DoSearch(in);
+	out = search.DoSearch(search_type, search_pattern);
 
 	it = out.begin();
 	ASSERT_EQ(out.size(), 4);


### PR DESCRIPTION
SearchInput class가 method없는 data만 들어있는 class라 별도로 class로 유지할 필요성 없음.
SearchCondition 생성 시에는 search pattern만 필요한데 불필요한 정보도 함께 전달되고 있어 수정.
search type이 잘못 들어왔을 경우 예외 처리 추가